### PR TITLE
adjust end-of-day time to match server

### DIFF
--- a/src/components/BackgroundPedometer.js
+++ b/src/components/BackgroundPedometer.js
@@ -82,7 +82,7 @@ class BackgroundPedometer extends React.Component {
       const day0Start = new Date(day0);
       const day0End = new Date(day0);
       day0Start.setHours(6,0,0,0);
-      day0End.setHours(24,0,0,0);
+      day0End.setHours(20,0,0,0);
 
       dispatch(setCampaignDates(day0Start, day0End, length, difficultyLevel, stepGoalDayOne));
     }


### PR DESCRIPTION
day now ends (as far as the pedometer is concerned) at 8:00, not midnight. this matches the time of the end-of-day event from the server.